### PR TITLE
chore: Support multiple targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
           APP_ID: id of the app
           WHATS_NEW: "detail item that has changed"
           BUILD_NUMBER: the build number you want to change
-          PLATFORM: the platform to target, ios/visionos/macos
+          PLATFORM: the platform to target, IOS, MAC_OS, TV_OS, VISION_OS
 
 ```
 
@@ -42,7 +42,7 @@ export PRIVATE_KEY=appstore connect api private key
 export APP_ID=app id
 export WHATS_NEW="Your update text, max 4000 chars"
 export BUILD_NUMBER= your build number
-export PLATFORM= ios, visionos or macos
+export PLATFORM= IOS, MAC_OS, TV_OS, VISION_OS
 python3 ./main.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Upload Release Notes to TestFlight
-        uses: nthState/UploadTestFlightReleaseNotes@v2.0.0
+        uses: nthState/UploadTestFlightReleaseNotes@v2.0.1
         with:
           ISSUER_ID: ${{ secrets.APPCONNECT_API_ISSUER }}
           KEY_ID: ${{ secrets.APPCONNECT_API_KEY_ID }}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ jobs:
           APP_ID: id of the app
           WHATS_NEW: "detail item that has changed"
           BUILD_NUMBER: the build number you want to change
+          PLATFORM: the platform to target, ios/visionos/macos
 
 ```
 
@@ -41,6 +42,7 @@ export PRIVATE_KEY=appstore connect api private key
 export APP_ID=app id
 export WHATS_NEW="Your update text, max 4000 chars"
 export BUILD_NUMBER= your build number
+export PLATFORM= ios, visionos or macos
 python3 ./main.py
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   BUILD_NUMBER:
     description: 'The build number to target'
     required: true
+  PLATFORM:
+    description: 'The platform to target, ios/visionos/macos'
+    required: false
 
 runs:
   using: 'composite'
@@ -36,6 +39,7 @@ runs:
         APP_ID: ${{ inputs.APP_ID }}
         WHATS_NEW: ${{ inputs.WHATS_NEW }}
         BUILD_NUMBER: ${{ inputs.BUILD_NUMBER }}
+        PLATFORM: ${{ inputs.PLATFORM }}
       run: |
         mkdir -p api_venv
         cd api_venv

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: 'The build number to target'
     required: true
   PLATFORM:
-    description: 'The platform to target, ios/visionos/macos'
+    description: 'The platform to target, IOS, MAC_OS, TV_OS, VISION_OS'
     required: false
 
 runs:

--- a/main.py
+++ b/main.py
@@ -27,19 +27,15 @@ class UploadTestFlightReleaseNotes:
 		return encoded_token
 		
 	def filter_builds_for_platform(self, build):
-		#print(f"Check {self.platform} for {build}")
 		computedMinMacOsVersion = build['attributes']['computedMinMacOsVersion']
 		minOsVersion = build['attributes']['minOsVersion']
 		computedMinVisionOsVersion = build['attributes']['computedMinVisionOsVersion']
 		# print(f"computedMinMacOsVersion: {computedMinMacOsVersion}")
-# 		print(f"minOsVersion: {minOsVersion}")
-# 		print(f"computedMinVisionOsVersion: {computedMinVisionOsVersion}")
-# 		print(f"self.platform: {self.platform}")
+		# print(f"minOsVersion: {minOsVersion}")
+		# print(f"computedMinVisionOsVersion: {computedMinVisionOsVersion}")
 		if self.platform == 'visionos' and computedMinVisionOsVersion == None:
-			#print("visionos")
 			return True
 		if self.platform == 'ios' and computedMinVisionOsVersion != None:
-			#print("ios")
 			return True
 
 		return False
@@ -55,7 +51,8 @@ class UploadTestFlightReleaseNotes:
 		
 		# Find builds
 		versionId = ""
-		while versionId == "":
+		versionIdCounter = 0
+		while versionId == "" and versionIdCounter < 100:
 		
 			print("---Finding Build---")
 			URL = BASE_URL + 'builds?filter[app]=' + app_id + '&filter[version]=' + build_number
@@ -63,21 +60,22 @@ class UploadTestFlightReleaseNotes:
 			try:
 				
 				data = r.json()['data']
-				#print(f"data len: {len(data)}")
 				data = list(filter(self.filter_builds_for_platform, data))
-				#print(f"data len filtered: {len(data)}")
 				
-				versionId = data[0]['id']
-					
-				print(f"found versionId: {versionId}")
+				if len(data) > 0:
+					versionId = data[0]['id']
+					print(f"found versionId: {versionId}")
 					
 			except Exception as e:
 				print(f"Error: {e}")
 				time.sleep(60) #wait for 60 seconds
+				
+			versionIdCounter += 1
 		
 		# Find localizations
 		localizationId = ""
-		while localizationId == "":
+		localizationIdCounter = 0
+		while localizationId == "" and localizationIdCounter < 100:
 		
 			print("---Finding Localizations---")
 			URL = BASE_URL + 'builds/' + versionId + '/betaBuildLocalizations'
@@ -87,7 +85,8 @@ class UploadTestFlightReleaseNotes:
 			except Exception as e:
 				print(f"Error: {e}")
 				time.sleep(60) #wait for 60 seconds
-		
+				
+			localizationIdCounter += 1
 		
 		print("---Update What's New---")
 		URL = BASE_URL + 'betaBuildLocalizations/' + localizationId


### PR DESCRIPTION
chore: Support multiple targets

Closes #3 

If you have an App that has iOS and visionOS as separate uploads, we need to be able to set the correct text for the App, previously, we got the first version from the builds list, however, we need to get the correct build, there doesn't seem to be an API filter for this, and the filtering client side isn't the best