### PR TITLE
chore: bump cffi to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2024.2.2
-cffi==1.16.0
+cffi==2.0.0
 charset-normalizer==3.3.2
 cryptography==42.0.7
 idna==3.7


### PR DESCRIPTION
## Summary
- bump `cffi` from `1.16.0` to `2.0.0` in `requirements.txt`

## Why
`cffi==1.16.0` fails to build on Python 3.14 (missing `_PyErr_WriteUnraisableMsg` symbol during wheel build), which breaks this action on runners using Python 3.14.

`cffi==2.0.0` includes Python 3.14 support and fixes the install failure.